### PR TITLE
improve: reduce unnecessary cast

### DIFF
--- a/pkg/sql/plan/explain/explain_expr.go
+++ b/pkg/sql/plan/explain/explain_expr.go
@@ -62,6 +62,9 @@ func describeExpr(ctx context.Context, expr *plan.Expr, options *ExplainOptions)
 		case *plan.Const_U64Val:
 			result += strconv.FormatUint(val.U64Val, 10)
 
+		case *plan.Const_Fval:
+			result += strconv.FormatFloat(float64(val.Fval), 'f', -1, 32)
+
 		case *plan.Const_Dval:
 			result += strconv.FormatFloat(val.Dval, 'f', -1, 64)
 

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1171,6 +1171,8 @@ func checkNoNeedCast(constT, columnT types.Type, constExpr *plan.Expr_C) bool {
 			return constVal >= 0
 		case types.T_varchar:
 			return true
+		case types.T_float64, types.T_float32:
+			return true
 		default:
 			return false
 		}
@@ -1196,6 +1198,8 @@ func checkNoNeedCast(constT, columnT types.Type, constExpr *plan.Expr_C) bool {
 		case types.T_uint32:
 			return constVal <= math.MaxUint32
 		case types.T_uint64:
+			return true
+		case types.T_float64, types.T_float32:
 			return true
 		default:
 			return false

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1171,8 +1171,9 @@ func checkNoNeedCast(constT, columnT types.Type, constExpr *plan.Expr_C) bool {
 			return constVal >= 0
 		case types.T_varchar:
 			return true
-		case types.T_float64, types.T_float32:
-			return true
+		case types.T_float32:
+			//float32 has 6-7 significant digits.
+			return constVal <= 100000 && constVal >= -100000
 		default:
 			return false
 		}
@@ -1199,8 +1200,9 @@ func checkNoNeedCast(constT, columnT types.Type, constExpr *plan.Expr_C) bool {
 			return constVal <= math.MaxUint32
 		case types.T_uint64:
 			return true
-		case types.T_float64, types.T_float32:
-			return true
+		case types.T_float32:
+			//float32 has 6-7 significant digits.
+			return constVal <= 100000
 		default:
 			return false
 		}


### PR DESCRIPTION
for expr : float32Col = 10
old rule： we will build plan like: cast(float32Col as float64) = cast(10 as float64)
new rule: if integer， then plan like: float32Col = cast(10 as float32)

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: